### PR TITLE
Fix property type detection and subscription button logic

### DIFF
--- a/src/app/agent-subscriptions/page.tsx
+++ b/src/app/agent-subscriptions/page.tsx
@@ -384,6 +384,9 @@ export default function AgentSubscriptionsPage() {
                   const amount = subscription.transaction?.amount || subscription.amount || 0;
                   const txnRef = subscription.transaction?._id || subscription.transaction?.reference || subscription.transaction?.id || '-';
                   const txnStatus = subscription.transaction?.status || subscription.status || '-';
+                  const isFreePlan = ((planObj && ((planObj as any).basePrice === 0 || (planObj as any).isTrial)) ||
+                    /free|trial/i.test(String(planName)) ||
+                    Number(amount || 0) === 0);
 
                   return (
                     <div key={subscription._id || subscription.id} className="bg-white rounded-lg border border-gray-200 p-6">
@@ -417,7 +420,7 @@ export default function AgentSubscriptionsPage() {
                         <div className="text-xs text-gray-600">Ref: {txnRef} • {txnStatus}</div>
                       </div>
 
-                      {subscription.status === 'active' && (
+                      {subscription.status === 'active' && !isFreePlan && (
                         <button
                           onClick={() => {
                             setSelectedSubscription(subscription);

--- a/src/components/new-marketplace/PropertySlots.tsx
+++ b/src/components/new-marketplace/PropertySlots.tsx
@@ -25,38 +25,18 @@ const isJVProperty = (property: any): boolean => {
   if (!property) return false;
 
   // Check briefType first (most reliable)
-  if (property.briefType === "Joint Venture" ||
-      property.briefType === "jv" ||
-      property.briefType === "JV") {
+  const brief = String(property.briefType || "").toLowerCase();
+  if (brief === "joint venture" || brief === "jv") {
     return true;
   }
 
-  // Check category field
-  if (property.category === "joint-venture" || property.category === "jv") {
+  // Check category field explicitly for JV
+  const category = String(property.category || property.propertyCategory || "").toLowerCase();
+  if (category === "joint-venture" || category === "jv" || category === "joint venture") {
     return true;
   }
 
-  // Check propertyType for Land or Commercial (which are typically JV)
-  if (property.propertyType === "Land" ||
-      property.propertyType === "Commercial" ||
-      property.propertyType === "land" ||
-      property.propertyType === "commercial") {
-    return true;
-  }
-
-  // Check propertyCategory as fallback
-  if (property.propertyCategory === "Land" ||
-      property.propertyCategory === "Commercial" ||
-      property.propertyCategory === "land" ||
-      property.propertyCategory === "commercial") {
-    return true;
-  }
-
-  // Check type field
-  if (property.type === "land" || property.type === "commercial") {
-    return true;
-  }
-
+  // Do not infer JV from property type alone (e.g., Land/Commercial can be sell/rent)
   return false;
 };
 

--- a/src/hooks/useGlobalInspectionState.ts
+++ b/src/hooks/useGlobalInspectionState.ts
@@ -94,18 +94,18 @@ export const useGlobalInspectionState = () => {
 
   // Get property type for display
   const getPropertyType = useCallback((property: any) => {
-    // Check briefType first
+    // Prefer explicit briefType from backend
     if (property?.briefType) {
       return property.briefType;
     }
 
-    // Check propertyType and map to briefType
-    const propertyType = property?.propertyType;
-    if (propertyType === "Land" || propertyType === "Commercial") {
+    // Fallbacks: detect JV only when explicitly labeled as such
+    const category = String(property?.category || property?.propertyCategory || "").toLowerCase();
+    if (category === "joint-venture" || category === "jv" || category === "joint venture") {
       return "Joint Venture";
     }
 
-    // Default based on context or fall back to "Outright Sales"
+    // Otherwise default to Outright Sales (avoid inferring JV from propertyType alone)
     return "Outright Sales";
   }, []);
 


### PR DESCRIPTION
## Purpose

This PR addresses two key issues identified by the user:
1. Corrects the property type detection logic to stop incorrectly identifying sell/rent properties as Joint Venture (JV) properties
2. Improves the agent subscriptions page to only show the "Renew Subscription" button for active non-free plan subscriptions

## Code changes

### Property Type Detection (`PropertySlots.tsx` & `useGlobalInspectionState.ts`)
- **Removed automatic JV inference**: No longer automatically categorizes Land/Commercial properties as Joint Venture
- **Explicit JV detection**: Only identifies properties as JV when explicitly labeled with `briefType` or `category` fields containing "joint venture" or "jv"
- **Improved fallback logic**: Uses explicit backend `briefType` as primary source, with safer fallbacks that don't assume property type

### Agent Subscriptions (`page.tsx`)
- **Added free plan detection**: Implemented `isFreePlan` logic that checks for zero base price, trial status, free/trial keywords, or zero amount
- **Conditional button display**: "Renew Subscription" button now only appears for active subscriptions that are not free plans
- **Enhanced subscription filtering**: Prevents unnecessary renewal prompts for users on free or trial plansTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/37467ab76a7a4df48c7e4992e57d4e05/glow-field)

👀 [Preview Link](https://37467ab76a7a4df48c7e4992e57d4e05-glow-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>37467ab76a7a4df48c7e4992e57d4e05</projectId>-->
<!--<branchName>glow-field</branchName>-->