### PR TITLE
Add pending activation banner for paused deal sites

### DIFF
--- a/src/app/deal-site/page.tsx
+++ b/src/app/deal-site/page.tsx
@@ -511,9 +511,11 @@ export default function DealSitePage() {
         const res = await POST_REQUEST(`${URLS.BASE}/account/dealSite/setUp`, payload, token);
         hidePreloader();
         if ((res as any)?.success) {
-          toast.success("Deal Site created");
+          toast.success("Setup complete. Your deal site is pending activation.");
           setSlugLocked(true);
+          setIsPaused(true);
           setActiveView("manage");
+          setActiveTab("overview");
           return;
         }
         throw new Error((res as any)?.message || "Setup failed");
@@ -1490,7 +1492,7 @@ export default function DealSitePage() {
                     disabled={saving}
                     className="inline-flex items-center gap-2 px-6 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg disabled:opacity-60"
                   >
-                    <Save size={16} /> {saving ? "Saving..." : "Save & Go Live"}
+                    <Save size={16} /> {saving ? "Saving..." : "Save & Finish Setup"}
                   </button>
                 )}
               </div>
@@ -1498,6 +1500,16 @@ export default function DealSitePage() {
           ) : (
             <>
               {ManageHeader}
+              {isPaused && slugLocked && (
+                <div className="mb-4 p-4 rounded-lg border border-yellow-200 bg-yellow-50 text-yellow-800 flex items-center justify-between gap-3">
+                  <div className="text-sm">
+                    <span className="font-semibold">Pending activation.</span> Your deal site setup is complete but paused by default. Click Resume to make it live.
+                  </div>
+                  <button onClick={resumeDealSite} className="inline-flex items-center gap-2 px-3 py-2 border border-yellow-300 rounded-lg text-sm bg-white hover:bg-yellow-100">
+                    <Play size={16} /> Resume now
+                  </button>
+                </div>
+              )}
 
               <Tabs
                 active={activeTab}


### PR DESCRIPTION
## Purpose
Improve the user experience after deal site setup completion by clearly indicating that the site is pending activation. The user wanted to automatically show on the deal-site page that the deal site is pending activation with a button to resume it, since deal sites are paused by default after setup.

## Code changes
- Updated setup completion toast message to indicate pending activation status
- Set deal site to paused state (`setIsPaused(true)`) after successful setup
- Navigate to overview tab after setup completion
- Changed button text from "Save & Go Live" to "Save & Finish Setup" 
- Added yellow notification banner that appears when deal site is paused and setup is complete
- Banner includes clear messaging about pending activation and a "Resume now" button
- Banner only shows when `isPaused && slugLocked` conditions are metTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/37467ab76a7a4df48c7e4992e57d4e05/swoosh-verse)

👀 [Preview Link](https://37467ab76a7a4df48c7e4992e57d4e05-swoosh-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>37467ab76a7a4df48c7e4992e57d4e05</projectId>-->
<!--<branchName>swoosh-verse</branchName>-->