### PR TITLE
Add seller card and share details functionality to inspection page

### DIFF
--- a/src/app/field-agent-inspection/[id]/page.tsx
+++ b/src/app/field-agent-inspection/[id]/page.tsx
@@ -594,7 +594,7 @@ export default function InspectionDetailPage() {
                     </button>
                   </div>
 
-                  {Boolean((inspection as any)?.owner) ? (
+                  {typeof (inspection as any)?.owner === "object" && (inspection as any)?.owner?.fullName ? (
                     <div className="space-y-4">
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
## Purpose
Based on user requirements to enhance the field agent inspection page by adding seller information display and implementing bidirectional contact sharing functionality between buyers and sellers through confirmation modals and API integration.

## Code changes
- **Added seller information card** with name, phone, and email display alongside existing buyer card
- **Implemented share details buttons** on both buyer and seller cards with distinct styling (blue for buyer-to-seller, emerald for seller-to-buyer)
- **Added confirmation modal** to verify sharing actions before execution
- **Integrated API endpoint** `/account/inspectionsFieldAgent/:inspectionId/sendDetails` with payload `{send: "buyer-to-seller"}` or `{send: "seller-to-buyer"}`
- **Added loading states** with overlay preloader during API requests
- **Enhanced UI components** with Share2 icon from lucide-react and proper error handling with toast notificationsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b74f389513d340a9a406f8fa9f604659/curry-verse)

👀 [Preview Link](https://b74f389513d340a9a406f8fa9f604659-curry-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b74f389513d340a9a406f8fa9f604659</projectId>-->
<!--<branchName>curry-verse</branchName>-->