### PR TITLE
Improve guest input with plus/minus buttons and format booked dates

### DIFF
--- a/src/components/shortlet/ShortletBookingModal.tsx
+++ b/src/components/shortlet/ShortletBookingModal.tsx
@@ -543,28 +543,17 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
                             Math.max(1, Number(formik.values.guests || 1) - 1)
                           )
                         }
-                        className="h-8 w-8 inline-flex items-center justify-center rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                        disabled={Number(formik.values.guests || 1) <= 1}
+                        className={`h-8 w-8 inline-flex items-center justify-center rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 ${Number(formik.values.guests || 1) <= 1 ? "opacity-50 cursor-not-allowed" : ""}`}
                       >
                         -
                       </button>
                       <input
-                        type="number"
-                        min={1}
-                        max={maxGuests}
+                        type="text"
+                        readOnly
                         value={formik.values.guests}
-                        onChange={(e) =>
-                          formik.setFieldValue(
-                            "guests",
-                            Math.min(maxGuests, Math.max(1, Number(e.target.value) || 1))
-                          )
-                        }
-                        onBlur={() =>
-                          formik.setFieldValue(
-                            "guests",
-                            Math.min(maxGuests, Math.max(1, Number(formik.values.guests) || 1))
-                          )
-                        }
-                        className="w-full outline-none text-sm text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        className="w-full select-none text-sm text-center cursor-default bg-transparent outline-none"
+                        aria-label="Guest count"
                       />
                       <button
                         type="button"
@@ -575,7 +564,8 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
                             Math.min(maxGuests, Number(formik.values.guests || 1) + 1)
                           )
                         }
-                        className="h-8 w-8 inline-flex items-center justify-center rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                        disabled={Number(formik.values.guests || 1) >= maxGuests}
+                        className={`h-8 w-8 inline-flex items-center justify-center rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 ${Number(formik.values.guests || 1) >= maxGuests ? "opacity-50 cursor-not-allowed" : ""}`}
                       >
                         +
                       </button>

--- a/src/components/shortlet/ShortletBookingModal.tsx
+++ b/src/components/shortlet/ShortletBookingModal.tsx
@@ -534,6 +534,19 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
                     <label className="block text-sm font-medium text-gray-700">Guests</label>
                     <div className={`flex items-center bg-white border ${formik.errors.guests ? "border-red-400" : "border-gray-300"} rounded-lg px-3 py-2 gap-2`}>
                       <Users className="w-4 h-4 text-emerald-600" />
+                      <button
+                        type="button"
+                        aria-label="Decrease guests"
+                        onClick={() =>
+                          formik.setFieldValue(
+                            "guests",
+                            Math.max(1, Number(formik.values.guests || 1) - 1)
+                          )
+                        }
+                        className="h-8 w-8 inline-flex items-center justify-center rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                      >
+                        -
+                      </button>
                       <input
                         type="number"
                         min={1}
@@ -545,8 +558,27 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
                             Math.min(maxGuests, Math.max(1, Number(e.target.value) || 1))
                           )
                         }
-                        className="w-full outline-none text-sm"
+                        onBlur={() =>
+                          formik.setFieldValue(
+                            "guests",
+                            Math.min(maxGuests, Math.max(1, Number(formik.values.guests) || 1))
+                          )
+                        }
+                        className="w-full outline-none text-sm text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                       />
+                      <button
+                        type="button"
+                        aria-label="Increase guests"
+                        onClick={() =>
+                          formik.setFieldValue(
+                            "guests",
+                            Math.min(maxGuests, Number(formik.values.guests || 1) + 1)
+                          )
+                        }
+                        className="h-8 w-8 inline-flex items-center justify-center rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                      >
+                        +
+                      </button>
                     </div>
                     {formik.errors.guests && (
                       <p className="mt-1 text-xs text-red-500">{formik.errors.guests as string}</p>
@@ -568,13 +600,16 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
 
                   {bookedIntervals.length > 0 && (
                     <div className="md:col-span-2 bg-red-50 rounded-lg p-3 border border-red-200 text-red-800">
-                      <p className="text-sm font-semibold mb-1">Some dates are unavailable</p>
+                      <p className="text-sm font-semibold mb-1">Booked dates</p>
                       <ul className="text-xs list-disc pl-5 space-y-0.5 max-h-24 overflow-auto">
-                        {bookedIntervals.map((b: { start: string | Date; end: string | Date }, i: any) => (
+                        {bookedIntervals.slice(0, 5).map((b: { start: string | Date; end: string | Date }, i: any) => (
                           <li key={i}>
-                            {new Date(b.start).toLocaleString()} - {new Date(b.end).toLocaleString()}
+                            {new Date(b.start).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}
+                            {" - "}
+                            {new Date(b.end).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}
                           </li>
                         ))}
+                        {bookedIntervals.length > 5 && <li>… and more</li>}
                       </ul>
                     </div>
                   )}


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR improves the booking modal's guest input functionality and booked dates display. Users requested:
1. Plus/minus buttons for guest selection instead of allowing manual number input
2. Better formatting of booked dates with readable format and limited display
3. Prevention of typing arbitrary numbers in the guest field

## Code changes

**Guest Input Enhancements:**
- Replaced number input with read-only text field and plus/minus buttons
- Added decrease button (-) with minimum limit of 1 guest
- Added increase button (+) with maximum limit based on `maxGuests`
- Buttons are properly disabled when limits are reached
- Input field is now read-only to prevent manual typing

**Booked Dates Improvements:**
- Changed section title from "Some dates are unavailable" to "Booked dates"
- Updated date formatting to use `toLocaleDateString()` for better readability (removes time)
- Limited display to first 5 booked dates with "… and more" indicator when there are additional dates
- Maintained responsive design and styling consistencyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/48e69a2ab23c40e2976bc27c89348252/flare-hub)

👀 [Preview Link](https://48e69a2ab23c40e2976bc27c89348252-flare-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>48e69a2ab23c40e2976bc27c89348252</projectId>-->
<!--<branchName>flare-hub</branchName>-->