### PR TITLE
Update shortlet commission to 7% and add service charge

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -329,7 +329,7 @@ const Login: FC = () => {
             Don&apos;t have an account?{" "}
             <Link
               className="font-semibold text-[#09391C]"
-              href={fromParam ? `/auth/register?from=${encodeURIComponent(fromParam)}` : "/auth/register"}
+              href={encodedRedirectTarget ? `/auth/register?from=${encodedRedirectTarget}` : "/auth/register"}
             >
               Sign Up
             </Link>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -231,10 +231,10 @@ const Login: FC = () => {
 
                     const userPayload = result.data.user;
 
-                    const redirectUrl = fromParam || sessionStorage.getItem('redirectAfterLogin');
+                    const redirectUrl = resolvedRedirectTarget || sessionStorage.getItem('redirectAfterLogin');
                     if (redirectUrl) {
                       try { sessionStorage.removeItem('redirectAfterLogin'); } catch {}
-                      router.push(redirectUrl.startsWith('/') ? redirectUrl : decodeURIComponent(redirectUrl));
+                      router.push(redirectUrl);
                       return;
                     }
 

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -83,10 +83,10 @@ const Login: FC = () => {
     setOverlayVisible(true);
 
     setTimeout(() => {
-      const redirectUrl = fromParam || sessionStorage.getItem('redirectAfterLogin');
+      const redirectUrl = resolvedRedirectTarget || sessionStorage.getItem('redirectAfterLogin');
       if (redirectUrl) {
         try { sessionStorage.removeItem('redirectAfterLogin'); } catch {}
-        router.push(redirectUrl.startsWith('/') ? redirectUrl : decodeURIComponent(redirectUrl));
+        router.push(redirectUrl);
         setOverlayVisible(false);
         return;
       }

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -95,7 +95,7 @@ const Login: FC = () => {
 
       setOverlayVisible(false);
     }, 1500);
-  }, [router, setUser, fromParam]);
+  }, [router, setUser, resolvedRedirectTarget]);
  
   const formik = useFormik({
     initialValues: {

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -69,10 +69,10 @@ const Login: FC = () => {
   });
 
   useEffect(() => {
-    if (fromParam) {
-      try { sessionStorage.setItem('redirectAfterLogin', decodeURIComponent(fromParam)); } catch {}
+    if (resolvedRedirectTarget) {
+      try { sessionStorage.setItem('redirectAfterLogin', resolvedRedirectTarget); } catch {}
     }
-  }, [fromParam]);
+  }, [resolvedRedirectTarget]);
 
   const handleAuthSuccess = useCallback((response: any) => {
     const userPayload = response.data.user;

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -144,10 +144,10 @@ const Login: FC = () => {
 
           const userPayload = response.data.user;
 
-          const redirectUrl = fromParam || sessionStorage.getItem('redirectAfterLogin');
+          const redirectUrl = resolvedRedirectTarget || sessionStorage.getItem('redirectAfterLogin');
           if (redirectUrl) {
             try { sessionStorage.removeItem('redirectAfterLogin'); } catch {}
-            router.push(redirectUrl.startsWith('/') ? redirectUrl : decodeURIComponent(redirectUrl));
+            router.push(redirectUrl);
             return;
           }
 

--- a/src/components/post-property-components/Step4OwnershipDeclaration.tsx
+++ b/src/components/post-property-components/Step4OwnershipDeclaration.tsx
@@ -140,7 +140,7 @@ const Step4OwnershipDeclaration: React.FC<StepProps> = () => {
     }
 
     if (briefType === "shortlet") {
-      return `I, ${userName}, agree that Khabiteq realty shall earn 5% of the total value generated from this transaction as commission when the deal is closed.`;
+      return `I, ${userName}, agree that Khabiteq realty shall earn 7% of the total value generated from this transaction as commission when the deal is closed.`;
     }
 
     return "";

--- a/src/components/post-property-components/Step4OwnershipDeclaration.tsx
+++ b/src/components/post-property-components/Step4OwnershipDeclaration.tsx
@@ -359,10 +359,12 @@ const Step4OwnershipDeclaration: React.FC<StepProps> = () => {
               <span className="font-medium">Legal Owner:</span>{" "}
               {propertyData.isLegalOwner ? "Yes" : "Authorized Representative"}
             </p>
-            <p>
-              <span className="font-medium">Commission Rate:</span>{" "}
-              {getCommissionRate()}%
-            </p>
+            {commissionRate !== null && (
+              <p>
+                <span className="font-medium">Commission Rate:</span>{" "}
+                {commissionRate}%
+              </p>
+            )}
             <p>
               <span className="font-medium">Contact:</span>{" "}
               {propertyData.contactInfo.firstName &&

--- a/src/components/post-property-components/Step4OwnershipDeclaration.tsx
+++ b/src/components/post-property-components/Step4OwnershipDeclaration.tsx
@@ -205,7 +205,7 @@ const Step4OwnershipDeclaration: React.FC<StepProps> = () => {
       return {
         title: "COMMISSION AGREEMENT - Shortlet",
         details: [
-          "• Khabiteq earns 5% of the total value generated from this transaction as commission when the deal is closed",
+          "• Khabiteq earns 7% of the total value generated from this transaction as commission when the deal is closed",
         ],
       };
     }

--- a/src/components/post-property-components/Step4OwnershipDeclaration.tsx
+++ b/src/components/post-property-components/Step4OwnershipDeclaration.tsx
@@ -15,6 +15,8 @@ import {
   getCommissionText,
   briefTypeConfig,
 } from "@/data/comprehensive-post-property-config";
+import { useAppSelector } from "@/store/hooks";
+import { selectShowCommissionFee } from "@/store/subscriptionFeaturesSlice";
 import "react-phone-number-input/style.css";
 import "@/styles/phone-input.css";
 import { StepProps } from "@/types/post-property.types";

--- a/src/components/post-property-components/Step4OwnershipDeclaration.tsx
+++ b/src/components/post-property-components/Step4OwnershipDeclaration.tsx
@@ -214,6 +214,7 @@ const Step4OwnershipDeclaration: React.FC<StepProps> = () => {
   };
 
   const commissionInfo = getCommissionDetails();
+  const commissionRate = getCommissionRate();
 
   return (
     <motion.div

--- a/src/components/post-property-components/Step4OwnershipDeclaration.tsx
+++ b/src/components/post-property-components/Step4OwnershipDeclaration.tsx
@@ -86,13 +86,19 @@ const Step4OwnershipDeclaration: React.FC<StepProps> = () => {
     return user?.userType === "Agent" ? "agent" : "landowner";
   };
 
-  const getCommissionRate = () => {
+  const showCommissionFee = useAppSelector(selectShowCommissionFee);
+
+  const getCommissionRate = (): number | null => {
     const userType = getUserType();
-    const config =
-      briefTypeConfig[
-        propertyData.propertyType as keyof typeof briefTypeConfig
-      ];
-    if (!config) return 10;
+    const briefType = propertyData.propertyType as keyof typeof briefTypeConfig;
+    const config = briefTypeConfig[briefType];
+    // Shortlet: enforce 7% for both agents and landowners
+    if (briefType === "shortlet") return 7;
+    if (!config) return userType === "agent" ? 50 : 10;
+
+    // For agents on non-shortlet briefs, hide commission if subscription removes commission
+    if (userType === "agent" && !showCommissionFee) return null;
+
     return userType === "agent"
       ? config.commission.agent
       : config.commission.landowner;

--- a/src/components/post-property-components/Step4OwnershipDeclaration.tsx
+++ b/src/components/post-property-components/Step4OwnershipDeclaration.tsx
@@ -288,7 +288,7 @@ const Step4OwnershipDeclaration: React.FC<StepProps> = () => {
         </div>
 
         {/* Commission Agreement */}
-        {propertyData.propertyType && (
+        {propertyData.propertyType && commissionRate !== null && (
           <div className="border border-[#E5E7EB] rounded-lg p-6">
             <h3 className="text-xl font-semibold text-[#09391C] mb-4">
               {commissionInfo.title}

--- a/src/components/shortlet/ShortletBookingModal.tsx
+++ b/src/components/shortlet/ShortletBookingModal.tsx
@@ -214,7 +214,7 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
     validateOnBlur: true,
     validateOnChange: false,
     onSubmit: async (values) => {
-      const { total: computedTotal } = useAmount(
+      const { payable: computedPayable } = useAmount(
         nightly,
         cleaningFee,
         values.checkIn?.toISOString(),
@@ -223,7 +223,7 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
         monthlyDiscountPercent,
         securityDeposit
       );
-      const total = computedTotal;
+      const totalPayable = computedPayable;
 
       const apiPayload: any = {
         bookedBy: {
@@ -240,7 +240,7 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
           ...(values.note.trim() ? { note: values.note.trim() } : {}),
         },
         paymentDetails: {
-          amountToBePaid: total,
+          amountToBePaid: totalPayable,
         },
         bookingMode: mode,
       };

--- a/src/components/shortlet/ShortletBookingModal.tsx
+++ b/src/components/shortlet/ShortletBookingModal.tsx
@@ -651,6 +651,14 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
                       <p className="text-sm text-gray-600">Estimated Total</p>
                       <p className="text-base font-bold text-emerald-700">{formatCurrency(total)}</p>
                     </div>
+                    <div className="flex items-center justify-between mt-2">
+                      <p className="text-sm text-gray-600">Service Charge (8%)</p>
+                      <p className="text-sm font-semibold">{formatCurrency(serviceCharge)}</p>
+                    </div>
+                    <div className="flex items-center justify-between mt-1">
+                      <p className="text-sm text-gray-600">Total Payable</p>
+                      <p className="text-base font-bold text-emerald-700">{formatCurrency(payable)}</p>
+                    </div>
                   </div>
                 </div>
               ) : (

--- a/src/components/shortlet/ShortletBookingModal.tsx
+++ b/src/components/shortlet/ShortletBookingModal.tsx
@@ -348,7 +348,7 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
   };
 
   const footerButtonText = step === 1 ? "Next" : mode === "instant" ? "Proceed to Payment" : "Submit Request";
-  const canProceedStep1 = total > 0 && nights > 0;
+  const canProceedStep1 = payable > 0 && nights > 0;
   const canSubmitStep2 = (
     typeof formik.values.fullName === "string" && formik.values.fullName.trim().length > 0 &&
     typeof formik.values.email === "string" && formik.values.email.trim().length > 0 &&
@@ -459,7 +459,7 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
                     <li>Select preferred check-in/out dates and times. Add guests and an optional note.</li>
                     <li>Enter your contact information (used to contact you about approval).</li>
                     <li>Submit your request. The host has a limited time window to accept.</li>
-                    <li>If accepted, you’ll be prompted to complete payment to confirm the booking. If declined/expired, you’ll be notified.</li>
+                    <li>If accepted, you��ll be prompted to complete payment to confirm the booking. If declined/expired, you’ll be notified.</li>
                   </ul>
                 )}
               </div>

--- a/src/components/shortlet/ShortletBookingModal.tsx
+++ b/src/components/shortlet/ShortletBookingModal.tsx
@@ -307,6 +307,8 @@ const ShortletBookingModal: React.FC<ShortletBookingModalProps> = ({ isOpen, onC
   );
 
   const total = amountInfo.total;
+  const serviceCharge = amountInfo.serviceCharge || 0;
+  const payable = amountInfo.payable || total;
 
   const proceedNext = async () => {
     try {

--- a/src/context/post-property-context.tsx
+++ b/src/context/post-property-context.tsx
@@ -392,8 +392,12 @@ export function PostPropertyProvider({ children }: { children: ReactNode }) {
   };
 
   const getUserCommissionRate = (): number => {
-    // Import moved to top of file to avoid require() in component
-    return 50; // Default commission rate - should be imported from config
+    const userType = getUserType();
+    const briefType = propertyData.propertyType as keyof typeof briefTypeConfig;
+    const config = (briefType && (briefTypeConfig as any)[briefType]) || null;
+    if (briefType === 'shortlet') return 7;
+    if (!config) return userType === 'agent' ? 50 : 10;
+    return userType === 'agent' ? config.commission.agent : config.commission.landowner;
   };
 
   const contextValue: PostPropertyContextType = {

--- a/src/context/post-property-context.tsx
+++ b/src/context/post-property-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useState, ReactNode, Dispatch, SetStateAction } from "react";
+import { briefTypeConfig } from "@/data/comprehensive-post-property-config";
 
 interface PropertyImage {
   file: File | null;

--- a/src/data/comprehensive-post-property-config.ts
+++ b/src/data/comprehensive-post-property-config.ts
@@ -66,8 +66,8 @@ export const briefTypeConfig = {
     icon: "📅",
     propertyCategories: [PROPERTY_CATEGORIES.RESIDENTIAL],
     commission: {
-      landowner: 5,
-      agent: 50,
+      landowner: 7,
+      agent: 7,
     },
   },
 };

--- a/src/hooks/useAmount.ts
+++ b/src/hooks/useAmount.ts
@@ -28,6 +28,8 @@ export default function useAmount(
 
   const subtotal = Math.max(0, base - discountAmount); // nightly charges only
   const total = subtotal + clean + secDep; // add fixed fees
+  const serviceCharge = Math.round(total * 0.08); // 8% service charge on total
+  const payable = total + serviceCharge;
 
   return {
     nights,
@@ -37,6 +39,8 @@ export default function useAmount(
     discountAmount,
     subtotal,
     total,
+    serviceCharge,
+    payable,
     cleaningFee: clean,
     securityDeposit: secDep,
   };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -99,7 +99,8 @@ export function middleware(request: NextRequest) {
   if (isUserProtectedRoute) {
     if (!userToken) {
       const loginUrl = new URL("/auth/login", request.url);
-      loginUrl.searchParams.set("from", pathname);
+      const fullPath = pathname + (request.nextUrl.search || "");
+      loginUrl.searchParams.set("from", fullPath);
       return NextResponse.redirect(loginUrl);
     }
     return NextResponse.next();


### PR DESCRIPTION
## Changes Made

### Commission Rate Updates
- Updated shortlet commission rate from 5% to 7% for both landowners and agents
- Modified commission configuration in `briefTypeConfig` for shortlet properties
- Updated commission display logic in Step4OwnershipDeclaration component
- Added conditional rendering to hide commission section when rate is null

### Service Charge Implementation
- Added 8% service charge calculation to shortlet bookings
- Updated `useAmount` hook to include `serviceCharge` and `payable` fields
- Modified ShortletBookingModal to display service charge and total payable amounts
- Updated booking submission to use payable amount instead of total

### Authentication Flow Improvements
- Replaced `fromParam` with `resolvedRedirectTarget` and `encodedRedirectTarget` variables
- Removed manual URL encoding/decoding operations in login component
- Updated middleware to preserve full URL path including query parameters for redirects

### Subscription Feature Integration
- Added `useAppSelector` and `selectShowCommissionFee` imports
- Implemented logic to conditionally show commission fees based on subscription features
- Updated commission rate calculation to respect subscription settings for agents

### Code Cleanup
- Removed redundant URL manipulation logic in multiple authentication success handlers
- Simplified redirect URL handling across login flows
- Updated commission agreement text to reflect new 7% rate for shortlets

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/461746aac75542a1a8143dab6f738fc0/zenith-space)

👀 [Preview Link](https://461746aac75542a1a8143dab6f738fc0-zenith-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>461746aac75542a1a8143dab6f738fc0</projectId>-->
<!--<branchName>zenith-space</branchName>-->